### PR TITLE
Update marked dependency to 0.8.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/ejrbuss/markdown-to-txt#readme",
   "dependencies": {
-    "marked": "^0.6.2"
+    "marked": "^0.8.2"
   },
   "devDependencies": {
     "@types/jest": "^24.0.13",


### PR DESCRIPTION
This is to address a security advisory for marked:

https://www.npmjs.com/advisories/1076