### PR TITLE
Fix README.md typo for GItHub-flavoured Markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ markdownToTxt('Some *quoted* `*code*`'); // "Some quoted *code*"
 | Option | Default | Description |
 |-|-|-|
 | escapeHtml | `true` | Escapes HTML in the final string |
-| gfp | `true` | Uses GitHub flavour markdown (passed through to marked) |
+| gfm | `true` | Uses GitHub flavour markdown (passed through to marked) |
 | pedantic | `false` | Conform to markdown<i></i>.pl (passed through to marked) |
 
 ## Contact


### PR DESCRIPTION
For GitHub-flavoured Markdown, [the property name was `gfm`](https://github.com/ejrbuss/markdown-to-txt/blob/master/src/markdown-to-txt.ts#L25), so this pull request just updates the `README.md` to match.