### PR TITLE
fix: require escape and unescape from the respective namespaces

### DIFF
--- a/dist/markdown-to-txt.js
+++ b/dist/markdown-to-txt.js
@@ -1,10 +1,14 @@
 "use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.markdownToTxt = void 0;
 const marked_1 = require("marked");
-const lodash_1 = require("lodash");
+const lodash_escape_1 = __importDefault(require("lodash.escape"));
+const lodash_unescape_1 = __importDefault(require("lodash.unescape"));
 const block = (text) => text + "\n\n";
-const escapeBlock = (text) => (0, lodash_1.escape)(text) + "\n\n";
+const escapeBlock = (text) => (0, lodash_escape_1.default)(text) + "\n\n";
 const line = (text) => text + "\n";
 const inline = (text) => text;
 const newline = () => "\n";
@@ -50,7 +54,7 @@ const TxtRenderer = {
  */
 function markdownToTxt(markdown, options) {
     const unmarked = (0, marked_1.marked)(markdown, Object.assign(Object.assign({}, options), { renderer: TxtRenderer }));
-    const unescaped = (0, lodash_1.unescape)(unmarked);
+    const unescaped = (0, lodash_unescape_1.default)(unmarked);
     const trimmed = unescaped.trim();
     return trimmed;
 }

--- a/src/markdown-to-txt.ts
+++ b/src/markdown-to-txt.ts
@@ -1,5 +1,6 @@
 import { marked } from "marked";
-import { escape, unescape } from "lodash";
+import escape from "lodash/escape";
+import unescape from "lodash/unescape";
 
 const block = (text: string) => text + "\n\n";
 const escapeBlock = (text: string) => escape(text) + "\n\n";

--- a/src/markdown-to-txt.ts
+++ b/src/markdown-to-txt.ts
@@ -1,6 +1,6 @@
 import { marked } from "marked";
-import escape from "lodash/escape";
-import unescape from "lodash/unescape";
+import escape from "lodash.escape";
+import unescape from "lodash.unescape";
 
 const block = (text: string) => text + "\n\n";
 const escapeBlock = (text: string) => escape(text) + "\n\n";


### PR DESCRIPTION
escape and unescape are taken from the global `lodash` namespace, which is installed in dev mode, because `jest` requires it. When the package is installed using only the `dependencies`, it fails.